### PR TITLE
[DOC-12548/release/3.5]: Fix the expansion on the Spark Connector menu item

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,4 +1,4 @@
-.xref:index.adoc[Spark Connector]
+* xref:index.adoc[]
 * xref:download-links.adoc[Download and API Reference]
 * xref:getting-started.adoc[Getting Started]
 * xref:dev-workflow.adoc[Development Workflow]


### PR DESCRIPTION

Removed surperfluous menu item from the top level.